### PR TITLE
Fix deprecated async_forward_entry_setup 

### DIFF
--- a/custom_components/windcentrale/__init__.py
+++ b/custom_components/windcentrale/__init__.py
@@ -19,8 +19,7 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.Conf
     hass.data[DOMAIN][entry.entry_id] = wind.Wind(hass, entry)
 
     # This creates an HA object for each platform.
-    for component in PLATFORMS:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, component))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/windcentrale/manifest.json
+++ b/custom_components/windcentrale/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jobvk/Home-Assistant-Windcentrale/issues",
   "loggers": ["boto3"],
-  "requirements": ["boto3==1.34.75", "pycognito==2024.2.0"],
-  "version": "2024.4.0"
+  "requirements": ["boto3==1.34.158", "pycognito==2024.5.1"],
+  "version": "2024.8.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto3==1.34.75
-pycognito==2024.2.0
+boto3==1.34.158
+pycognito==2024.5.1


### PR DESCRIPTION
Calling `hass.config_entries.async_forward_entry_setup` is deprecated and will be removed in Home Assistant `2025.6.` Instead, await `hass.config_entries.async_forward_entry_setups` as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

Issue link: https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ 